### PR TITLE
Nullish check for team member names

### DIFF
--- a/lib/models/member.dart
+++ b/lib/models/member.dart
@@ -19,7 +19,7 @@ class Member {
     return Member(
         id:  parsedJson["_id"],
         isAdmin: isAdminBool,
-        name: parsedJson["firstName"] + " " + parsedJson["lastName"],
+        name: (parsedJson["firstName"]??"") + " " + (parsedJson["lastName"]??""),
         email: parsedJson["email"]
     );
   }

--- a/lib/pages/project_submission.dart
+++ b/lib/pages/project_submission.dart
@@ -230,7 +230,7 @@ class _ProjSubmitState extends State<ProjSubmit> {
                       style: Theme.of(context).textTheme.headline4,
                     ),
                     onPressed: () {
-                      Navigator.of(context).push(MaterialPageRoute(builder: (context) => ProjSubmit()));
+                      Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => ProjSubmit()));
                     },
                   ),
                 ],


### PR DESCRIPTION
Backend team members might not have the fields for last or first names. Add a nullish check to avoid infinite loading.