### PR TITLE
ViewTeam, SeeInvites state refactors and updates to MenuOverlay Navigator push logic

### DIFF
--- a/lib/components/menu/MenuChoice.dart
+++ b/lib/components/menu/MenuChoice.dart
@@ -9,7 +9,6 @@ class MenuChoice extends StatelessWidget {
   Widget build(BuildContext context) {
     final mqData = MediaQuery.of(context);
     final screenWidth = mqData.size.width;
-    Color color = Theme.of(context).colorScheme.error;
     return Container(
         width: screenWidth/4,
         alignment: Alignment.centerRight,
@@ -19,7 +18,7 @@ class MenuChoice extends StatelessWidget {
               RawMaterialButton(
                 onPressed: onTap,
                 elevation: 2.0,
-                fillColor: color,
+                fillColor: Theme.of(context).colorScheme.error,
                 child: Icon(
                   icon,
                   size: 40.0,
@@ -29,9 +28,8 @@ class MenuChoice extends StatelessWidget {
                 shape: const CircleBorder(),
               ),
               Text(text,
-                style: TextStyle(
-                    color: color,
-                    fontSize: 14
+                style: Theme.of(context).textTheme.bodyText1.copyWith(
+                  color: Theme.of(context).colorScheme.error
                 ),
               )
             ]

--- a/lib/components/menu/MenuFunctions.dart
+++ b/lib/components/menu/MenuFunctions.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:provider/provider.dart';
 import 'package:thdapp/pages/login.dart';
 import 'package:thdapp/providers/check_in_items_provider.dart';
+import 'package:thdapp/providers/user_info_provider.dart';
 
 void logOut(entry, context) async {
   var prefs = await SharedPreferences.getInstance();
@@ -16,6 +17,7 @@ void logOut(entry, context) async {
           (route) => false
   );
   Provider.of<CheckInItemsModel>(context, listen: false).reset();
+  Provider.of<UserInfoModel>(context, listen: false).reset();
 }
 
 void setThemePref(theme, entry, context) async {

--- a/lib/components/menu/MenuOverlay.dart
+++ b/lib/components/menu/MenuOverlay.dart
@@ -64,11 +64,12 @@ OverlayEntry menuOverlay(BuildContext context) {
                                   text: "Schedule",
                                   onTap: () {
                                     entry.remove();
-                                    Navigator.push(
+                                    Navigator.pushAndRemoveUntil(
                                         context,
                                         MaterialPageRoute(builder: (context) =>
                                             EventsHomeScreen(),
-                                        )
+                                        ),
+                                            (route) => route.isFirst
                                     );
                                   },
                                 ),
@@ -77,11 +78,12 @@ OverlayEntry menuOverlay(BuildContext context) {
                                   text: "Project",
                                   onTap: () {
                                     entry.remove();
-                                    Navigator.push(
+                                    Navigator.pushAndRemoveUntil(
                                         context,
                                         MaterialPageRoute(builder: (context) =>
                                             ProjSubmit(),
-                                        )
+                                        ),
+                                        (route) => route.isFirst
                                     );
                                   },
                                 ),
@@ -90,11 +92,10 @@ OverlayEntry menuOverlay(BuildContext context) {
                                   text: "Home",
                                   onTap: () {
                                     entry.remove();
-                                    Navigator.push(
+                                    Navigator.pushAndRemoveUntil(
                                         context,
-                                        MaterialPageRoute(builder: (context) =>
-                                            Home(),
-                                        )
+                                        MaterialPageRoute(builder: (context) => Home()),
+                                            (route) => false
                                     );
                                   },
                                 ),
@@ -124,14 +125,16 @@ OverlayEntry menuOverlay(BuildContext context) {
                                 text: "Team",
                                 onTap: () {
                                   entry.remove();
-                                  Navigator.push(
+                                  Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();
+                                  Navigator.pushAndRemoveUntil(
                                     context,
-                                    MaterialPageRoute(builder: (context) =>
+                                    hasTeam ? MaterialPageRoute(builder: (context) =>
                                         ViewTeam(),
                                         settings: const RouteSettings(
                                           arguments: "",
                                         )
-                                    ),
+                                    ) : MaterialPageRoute(builder: (context) => TeamsList()),
+                                          (route) => route.isFirst
                                   );
                                 },
                               ),
@@ -140,11 +143,12 @@ OverlayEntry menuOverlay(BuildContext context) {
                                 text: "Scan",
                                 onTap: () {
                                   entry.remove();
-                                  Navigator.push(
+                                  Navigator.pushAndRemoveUntil(
                                       context,
                                       MaterialPageRoute(builder: (context) =>
                                           CheckIn(),
-                                      )
+                                      ),
+                                          (route) => route.isFirst
                                   );
                                 },
                               ),
@@ -153,11 +157,13 @@ OverlayEntry menuOverlay(BuildContext context) {
                                 text: "Profile",
                                 onTap: () {
                                   entry.remove();
-                                  Navigator.push(
+                                  Navigator.pushAndRemoveUntil(
                                     context,
                                     MaterialPageRoute(
                                         settings: const RouteSettings(name: "profpage"),
-                                        builder: (context) => const ProfilePage()),
+                                        builder: (context) => const ProfilePage()
+                                    ),
+                                          (route) => route.isFirst
                                   );
                                 },
                               ),

--- a/lib/components/menu/MenuOverlay.dart
+++ b/lib/components/menu/MenuOverlay.dart
@@ -8,7 +8,9 @@ import 'package:thdapp/pages/events/index.dart';
 import 'package:thdapp/pages/home.dart';
 import 'package:thdapp/pages/profile_page.dart';
 import 'package:thdapp/pages/project_submission.dart';
+import 'package:thdapp/pages/teams_list.dart';
 import 'package:thdapp/pages/view_team.dart';
+import 'package:thdapp/providers/user_info_provider.dart';
 import '../../../theme_changer.dart';
 import './MenuButton.dart';
 
@@ -16,6 +18,7 @@ OverlayEntry menuOverlay(BuildContext context) {
   final mqData = MediaQuery.of(context);
   final screenWidth = mqData.size.width;
   var _themeProvider = Provider.of<ThemeChanger>(context, listen: false);
+  bool hasTeam = Provider.of<UserInfoModel>(context, listen: false).hasTeam;
   OverlayEntry entry;
 
   entry = OverlayEntry(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import 'package:thdapp/providers/check_in_items_provider.dart';
+import 'package:thdapp/providers/user_info_provider.dart';
 import 'pages/login.dart';
 import 'theme_changer.dart';
 
@@ -11,6 +12,7 @@ void main() => runApp(
         providers: [
           ChangeNotifierProvider(create: (context) => CheckInItemsModel()),
           ChangeNotifierProvider(create: (_) => ThemeChanger(darkTheme)),
+          ChangeNotifierProvider(create: (context) => UserInfoModel())
         ],
       child: MyApp()
     )

--- a/lib/pages/create_team.dart
+++ b/lib/pages/create_team.dart
@@ -124,64 +124,6 @@ class _CreateTeamState extends State<CreateTeam> {
     );
   }
 
-  Widget _inviteMessage(){
-    TextEditingController inviteController = TextEditingController();
-    String emailInvite;
-
-    return AlertDialog(
-                  title: const Text('Send Invite'),
-                  content: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      TextFormField(
-                        decoration: const InputDecoration(labelText: "email"),
-                        style: const TextStyle(color: Colors.black),
-                        controller: inviteController,
-                        validator: (String value) {
-                          if (value.isEmpty) {
-                            return 'An email is required';
-                          }
-                          return null;
-                          },
-                          onSaved: (String value) {
-                            emailInvite = value;
-                            },
-                      ),
-                      Container( 
-                        padding: const EdgeInsets.fromLTRB(0, 40, 0, 0),
-                        child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              SolidButton(
-                                onPressed: () => Navigator.pop(context, 'Cancel'),
-                                text: "Cancel"
-                              ),
-                              SolidButton(
-                              text: "Send",
-                              onPressed: () async {
-                                await requestTeamMember(emailInvite, token);
-                              }
-                            )
-                          ]
-                        )
-                      )
-                    ]
-                  )
-      );
-  }
-
-  Widget _inviteMem()  {
-    return SolidButton(
-        text: "INVITE NEW MEMBER", 
-        onPressed: () {
-          showDialog(
-            context: context,
-            builder: (_) => _inviteMessage()
-          );
-        }
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final mqData = MediaQuery.of(context);
@@ -205,26 +147,23 @@ class _CreateTeamState extends State<CreateTeam> {
                         .start,
                     children: [
                       Column(
-                          mainAxisAlignment: MainAxisAlignment
-                              .start,
-                          crossAxisAlignment: CrossAxisAlignment
-                              .start,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            const SizedBox(height: 15,),
                             Text("TEAM INFO", style:
                             Theme.of(context).textTheme.headline1),
-                            SizedBox(height:screenHeight*0.02),
+                            const SizedBox(height: 10),
                             Text("Basic Info", style:
                             Theme.of(context).textTheme.headline4),
                             // SizedBox(height:screenHeight*0.02),
                             // _buildName(),
-                            SizedBox(height:screenHeight*0.02),
+                            const SizedBox(height: 15),
                             _buildTeamName(),
-                            SizedBox(height:screenHeight*0.02),
+                            const SizedBox(height: 20),
                             _buildTeamDesc(),
-                            SizedBox(height:screenHeight*0.02),
+                            const SizedBox(height: 20),
                             _visible(),
-                            SizedBox(height:screenHeight*0.02),
-                            _inviteMem()
                           ],
                       ),
                       Container(

--- a/lib/pages/project_submission.dart
+++ b/lib/pages/project_submission.dart
@@ -233,6 +233,7 @@ class _ProjSubmitState extends State<ProjSubmit> {
                       style: Theme.of(context).textTheme.headline4,
                     ),
                     onPressed: () {
+                      Navigator.pop(context);
                       Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => ProjSubmit()));
                     },
                   ),

--- a/lib/pages/see_invites.dart
+++ b/lib/pages/see_invites.dart
@@ -1,13 +1,126 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:thdapp/components/DefaultPage.dart';
-import 'package:thdapp/components/background_shapes/CurvedTop.dart';
 import 'package:thdapp/components/buttons/GradBox.dart';
 import 'package:thdapp/components/buttons/SolidButton.dart';
-import 'package:thdapp/components/topbar/TopBar.dart';
+import 'package:thdapp/providers/user_info_provider.dart';
 import 'team_api.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '/models/team.dart';
 import 'view_team.dart';
+
+class AcceptButtonRow extends StatelessWidget {
+  final Function acceptOnPressed;
+  final Function declineOnPressed;
+
+  const AcceptButtonRow({this.acceptOnPressed, this.declineOnPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row (
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        const SizedBox(width: 20,),
+        SolidButton(
+          text: "Accept",
+          onPressed: acceptOnPressed,
+        ),
+        const SizedBox(width: 20,),
+        SolidButton(
+          text: "Decline",
+          onPressed: declineOnPressed,
+        )
+      ],
+    );
+  }
+}
+
+class NoAcceptButtonRow extends StatelessWidget {
+  final Function cancelOnPressed;
+
+  const NoAcceptButtonRow({this.cancelOnPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row (
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        SolidButton(
+          text: "Cancel",
+          onPressed: cancelOnPressed,
+        )
+      ],
+    );
+  }
+}
+
+class RequestCard extends StatelessWidget {
+  final dynamic request;
+  final Function(dynamic) removeRequest;
+
+  const RequestCard(this.request, this.removeRequest);
+  
+  bool checkAdmin(BuildContext context) {
+    bool hasTeam = Provider.of<UserInfoModel>(context, listen: false).hasTeam;
+    if (!hasTeam) return false;
+    Team team = Provider.of<UserInfoModel>(context, listen: false).team;
+    List<String> adminIds = team.admins.map((mem) => mem.id).toList();
+    String id = Provider.of<UserInfoModel>(context, listen: false).id;
+    return adminIds.contains(id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String requestType = request['type'];
+    bool hasTeam = Provider.of<UserInfoModel>(context, listen: false).hasTeam;
+    bool canAccept = (!hasTeam && requestType == "INVITE")
+        || (hasTeam && requestType == "JOIN" && checkAdmin(context));
+
+
+    String inviteInfo = hasTeam ? request['user']['email'] : request['team']['name'];
+    String requestID = request['_id'];
+    String token = Provider.of<UserInfoModel>(context, listen: false).token;
+
+    return Card(
+        margin: const EdgeInsets.all(12),
+        color: Theme.of(context).colorScheme.background,
+        child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(requestType, style: Theme.of(context).textTheme.headline3),
+                const SizedBox(height: 10),
+                Text(inviteInfo, style: Theme.of(context).textTheme.bodyText2),
+                const SizedBox(height: 8),
+                canAccept ? AcceptButtonRow(acceptOnPressed: () async {
+                  await acceptRequest(token, requestID);
+                  removeRequest(request);
+                  await Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();
+                  if (requestType == 'INVITE') {
+                    Navigator.pushAndRemoveUntil(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => ViewTeam(),
+                            settings: const RouteSettings(
+                              arguments: "",
+                            )
+                        ), (route) => route.isFirst);
+                  }
+                }, declineOnPressed: () async {
+                  await declineRequest(token, requestID);
+                  removeRequest(request);
+                }) : NoAcceptButtonRow(cancelOnPressed: () async {
+                  await cancelRequest(token, requestID);
+                  removeRequest(request);
+                })
+              ],
+            )
+        )
+    );
+  }
+}
+
 
 class ViewInvites extends StatefulWidget {
   @override
@@ -16,157 +129,34 @@ class ViewInvites extends StatefulWidget {
 
 class _ViewInvitesState extends State<ViewInvites> {
 
-  bool isAdmin = false;
-  bool isMember = false;
-  String teamID = "";
-  Team team;
-  String token;
-  String memberID;
-  int numRequests;
-  List<Widget> requestsWidgetList = <Widget>[];
   List<dynamic> requestsList;
-  List<Widget> requestWidgetList = <Widget>[];
-  SharedPreferences prefs;
-  bool checkAdmin(String id){
-    return team.admins.map((e) => e.id).toList().contains(id);
+  Status fetchStatus = Status.notLoaded;
+
+  Future<void> fetchData() async {
+    String token = Provider.of<UserInfoModel>(context, listen: false).token;
+    bool hasTeam = Provider.of<UserInfoModel>(context, listen: false).hasTeam;
+    List<dynamic> fetchedList;
+    if (hasTeam) {
+      fetchedList = await getTeamMail(token);
+    } else {
+      fetchedList = await getUserMail(token);
+    }
+    setState(() {
+      fetchStatus = fetchedList == null ? Status.error : Status.loaded;
+      requestsList = fetchedList;
+    });
   }
 
-  void getData() async {
-    prefs = await SharedPreferences.getInstance();
-    token = prefs.getString('token');
-    memberID = prefs.getString('id');
-    isAdmin = prefs.getBool('admin');
-    team = await getUserTeam(token);
-    if (team == null){ 
-        requestsList = await getUserMail(token);
-        numRequests = requestsList.length;
-        _buildInvitesList();
-    } else {
-        requestsList = await getTeamMail(token);
-        numRequests = requestsList.length;
-        _buildInvitesList();
-    }
-    
+  void removeRequest(dynamic request) {
     setState(() {
+      requestsList.remove(request);
     });
   }
 
   @override
   initState() {
+    fetchData();
     super.initState();
-    getData();
-  }
-
-
-void _buildInvitesList(){
-  requestWidgetList = [];
-  for(int i = 0; i < requestsList.length; i++){
-    requestWidgetList.add(_buildRequests(i));
-  }
-}
-
-void _remRequest(String requestID) {
-    for (var r in requestsList) {
-      if (r['_id'] == requestID) {
-        requestsList.remove(r);
-        numRequests -= 1;
-        return;
-      }
-    }
-}
-
-Widget _buildInviteHeader() {
-    return Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text("INVITES", style: Theme.of(context).textTheme.headline1)
-        ]
-    );
-  }
-
- Widget _requestResponses(String requestType, String requestID){
-     if ((team == null && requestType == "INVITE") ||
-     (team != null && requestType == "JOIN")) {
-         return Row (
-             mainAxisAlignment: MainAxisAlignment.end,
-             children: [
-                const SizedBox(width: 20),
-                 SolidButton(
-                          text: "Accept",
-                          onPressed: () async {
-                            await acceptRequest(token, requestID);
-                            _remRequest(requestID);
-                            _buildInvitesList();
-                            setState(() {
-
-                            });
-                            if (requestType == 'INVITE') {
-                              Navigator.push(context,
-                                  MaterialPageRoute(builder: (context) => ViewTeam()));
-                            }
-                          }
-                ),
-                const SizedBox(width: 20),
-                SolidButton(
-                    text: "Decline",
-                    onPressed: () async {
-                        await declineRequest(token, requestID);
-                        _remRequest(requestID);
-                        _buildInvitesList();
-                        setState(() {
-
-                        });
-                    }
-                )
-             ]
-         );
-    } else {
-         return Row (
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-                 SolidButton(
-                          text: "Cancel",
-                          onPressed: () async {
-                            await cancelRequest(token, requestID);
-                            _remRequest(requestID);
-                            _buildInvitesList();
-                            setState(() {
-
-                            });
-                          }
-                    )
-            ]
-        );
-     }
- }
-  Widget _buildRequests(int index){
-    String requestType = requestsList[index]['type'];
-    String inviteInfo;
-    if (team != null){
-        inviteInfo = requestsList[index]['user']['email'];
-    } else {
-        inviteInfo = requestsList[index]['team']['name'];
-    }
-    String requestID = requestsList[index]['_id'];
-    Row btnRow = _requestResponses(requestType, requestID);
-    return Card(
-        margin: const EdgeInsets.all(12),
-        color: Theme.of(context).colorScheme.background,
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(requestType, style: Theme.of(context).textTheme.headline3),
-              const SizedBox(height: 10),
-              Text(inviteInfo, style: Theme.of(context).textTheme.bodyText2),
-              const SizedBox(height: 8),
-              btnRow
-            ],
-          )
-      )
-    );
   }
 
   @override
@@ -181,33 +171,43 @@ Widget _buildInviteHeader() {
           Container(
               alignment: Alignment.center,
               padding: const EdgeInsets.fromLTRB(0, 5, 0, 0),
-              child: GradBox(
-                  width: screenWidth*0.9,
-                  height: screenHeight*0.75,
-                  padding: const EdgeInsets.fromLTRB(20, 5, 20, 5),
-                  child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Container(
-                            padding: const EdgeInsets.fromLTRB(0, 10, 0, 10),
-                            child: _buildInviteHeader()
-                        ),
-                        if (prefs == null)
-                          const Center(child: CircularProgressIndicator())
-                        else if (requestsList.isEmpty)
-                          Text("No invites.", style: Theme.of(context).textTheme.bodyText2,)
-                        else
-                        Expanded(
-                          child: ListView.builder(
-                            itemCount: numRequests,
-                            itemBuilder: (BuildContext context, int index){
-                              return _buildRequests(index);
-                            },
+              child: RefreshIndicator(
+                onRefresh: fetchData,
+                child: GradBox(
+                    width: screenWidth*0.9,
+                    height: screenHeight*0.75,
+                    padding: const EdgeInsets.fromLTRB(20, 5, 20, 5),
+                    child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                              padding: const EdgeInsets.fromLTRB(0, 10, 0, 10),
+                              child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text("INVITES", style: Theme.of(context).textTheme.headline1)
+                                  ]
+                              )
                           ),
-                        )
-                      ]
-                  )
+                          if (fetchStatus == Status.loaded && requestsList.isNotEmpty)
+                            Expanded(
+                              child: ListView.builder(
+                                itemCount: requestsList.length,
+                                itemBuilder: (context, index) {
+                                  return RequestCard(requestsList[index], removeRequest);
+                                },
+                              ),
+                            )
+                          else if (fetchStatus == Status.loaded && requestsList.isEmpty)
+                            Text("No invites", style: Theme.of(context).textTheme.bodyText2,)
+                          else if (fetchStatus == Status.error)
+                              Text("Error loading invites", style: Theme.of(context).textTheme.bodyText2,)
+                          else
+                            const Center(child: CircularProgressIndicator())
+                        ]
+                    )
+                ),
               )
           )
     );

--- a/lib/pages/teams_list.dart
+++ b/lib/pages/teams_list.dart
@@ -68,7 +68,7 @@ class _TeamsListState extends State<TeamsList> {
       Text("TEAM", style: Theme.of(context).textTheme.headline2),
       IconButton(
           icon: const Icon(Icons.email, size: 30.0),
-          color: Theme.of(context).colorScheme.tertiaryContainer,
+          color: Theme.of(context).colorScheme.tertiary,
           onPressed: () {
             Navigator.push(
               context,
@@ -111,7 +111,6 @@ class _TeamsListState extends State<TeamsList> {
     } else {
       return SolidButton(
           text: "Ask to join",
-          color: Theme.of(context).colorScheme.tertiaryContainer,
           onPressed: () async {
             bool success = await requestTeam(teamID, token);
             if (success) {
@@ -130,7 +129,6 @@ class _TeamsListState extends State<TeamsList> {
   Widget _buildTeamDetailsBtn(String teamID) {
     SolidButton btn = SolidButton(
         text: "Details",
-        color: Theme.of(context).colorScheme.tertiaryContainer,
         onPressed: () {
           Navigator.push(
               context,
@@ -152,12 +150,7 @@ class _TeamsListState extends State<TeamsList> {
     );
     return Card(
         margin: const EdgeInsets.all(4),
-        color: Theme.of(context).colorScheme.surface.withOpacity(0.5),
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-            side: BorderSide(color: Theme.of(context).colorScheme.onSurface, width: 2.0),
-            borderRadius: BorderRadius.circular(4.0)
-        ),
+        color: Theme.of(context).colorScheme.background,
         child: Padding(
             padding: const EdgeInsets.all(24),
             child: Column(

--- a/lib/pages/teams_list.dart
+++ b/lib/pages/teams_list.dart
@@ -103,8 +103,9 @@ class _TeamsListState extends State<TeamsList> {
   Widget _buildTeamJoinBtn(String teamID) {
     if (requestedTeams.contains(teamID)) {
       return SolidButton(
-        text: "Awaiting response",
+        text: "Pending response",
         color: Colors.grey,
+        textColor: Colors.white,
         onPressed: null,
       );
     } else {

--- a/lib/pages/view_team.dart
+++ b/lib/pages/view_team.dart
@@ -193,7 +193,7 @@ class MemberListElement extends StatelessWidget {
                             WidgetSpan(
                                 child: Icon(Icons.star,
                                     size: 20,
-                                    color: Theme.of(context).colorScheme.tertiaryContainer)
+                                    color: Theme.of(context).colorScheme.tertiary)
                             )
                         ]
                     )),

--- a/lib/pages/view_team.dart
+++ b/lib/pages/view_team.dart
@@ -14,109 +14,288 @@ import 'see_invites.dart';
 import 'teams_list.dart';
 import 'create_team.dart';
 
-class ViewTeam extends StatefulWidget {
-  @override
-  _ViewTeamState createState() => _ViewTeamState();
-}
+class InviteMembersBtn extends StatelessWidget {
+  final Team team;
 
-class _ViewTeamState extends State<ViewTeam> {
+  const InviteMembersBtn(this.team);
 
-  bool isAdmin = false;
-  bool isMember = false;
-  bool hasTeam = false;
-  Team team;
-  String token;
-  String memberID;
-  List<String> adminIds;
+  // Show invitation dialog
+  Widget _inviteMessage(BuildContext context) {
+    TextEditingController inviteController = TextEditingController();
+    String emailInvite;
 
-  Future<void> _getData(String teamID, BuildContext context) async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    token = prefs.getString('token');
-    memberID = prefs.getString('id');
-
-    if (teamID == '' && !hasTeam) { //if not on a team, redirects to the teams list page
-      Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) =>
-              TeamsList())
-      );
-      return;
-    } else if (teamID != ''){
-      team = await getTeamInfo(teamID, token);
-    }
-
-    adminIds = team.admins.map((mem) => mem.id).toList();
-    isAdmin = adminIds.contains(memberID);
-    isMember = team.members.map((e) => e.id).contains(memberID);
-  }
-
-  @override
-  initState() {
-    super.initState();
-  }
-
-  Widget _buildEditTeam() {
-    if (isAdmin && isMember) {
-      return SolidButton(
-          text: "EDIT TEAM NAME AND INFO",
+    return AlertDialog(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      title: Text('Send Invite', style: Theme.of(context).textTheme.headline1),
+      content: TextFormField(
+        decoration: const InputDecoration(labelText: "email"),
+        style: Theme.of(context).textTheme.bodyText2,
+        controller: inviteController,
+        validator: (String value) {
+          if (value.isEmpty) {
+            return 'An email is required';
+          }
+          return null;
+        },
+        onChanged: (String value) {
+          emailInvite = value;
+        },
+      ),
+      actions: [
+        TextButton(
+          child: Text(
+            "Cancel",
+            style: Theme.of(context
+            ).textTheme.headline4,
+          ),
           onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) =>
-                  CreateTeam()),
-            );
+            Navigator.of(context).pop();
           },
-          color: Theme
-              .of(context)
-              .colorScheme
-              .primary);
-    } else {
-      return Container();
-    }
-  }
-
-  Widget _buildTeamMail() {
-    if (isAdmin && isMember) {
-      return Align(
-          alignment: Alignment.centerRight,
-          child: IconButton(
-              icon: const Icon(Icons.email, size: 30.0),
-              color: Theme
-                  .of(context)
-                  .colorScheme
-                  .tertiaryContainer,
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) =>
-                      ViewInvites()),
-                );
-              }
-          )
-      );
-    } else {
-      return Container();
-    }
-  }
-
-
-  Widget _buildTeamHeader() {
-    return SizedBox(
-      height: 50,
-      child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text("TEAM", style: Theme
-                .of(context)
-                .textTheme
-                .headline1),
-            _buildTeamMail()
-          ]
-      )
+        ),
+        TextButton(
+          child: Text(
+            "Send",
+            style: Theme.of(context
+            ).textTheme.headline4,
+          ),
+          onPressed: () async {
+            Navigator.of(context).pop();
+            String token = Provider.of<UserInfoModel>(context, listen: false).token;
+            await requestTeamMember(emailInvite, token);
+          },
+        ),
+      ],
     );
   }
 
-  Widget _buildTeamDesc() {
+  @override
+  Widget build(BuildContext context) {
+    return SolidButton(
+        text: "INVITE NEW MEMBER",
+        onPressed: () {
+          showDialog(
+              context: context,
+              builder: (context) => _inviteMessage(context)
+          );
+        },
+        color: Theme
+            .of(context)
+            .colorScheme
+            .primary);
+  }
+}
+
+class LeaveJoinTeamBtn extends StatelessWidget {
+  final Team team;
+  final bool isAdmin;
+  final List<String> adminIds;
+
+  const LeaveJoinTeamBtn(this.team, this.isAdmin, this.adminIds);
+
+  @override
+  Widget build(BuildContext context) {
+    String buttonText = "Leave Team";
+    String token = Provider.of<UserInfoModel>(context, listen: false).token;
+    return SolidButton(
+        text: buttonText,
+        onPressed: () async {
+          if (isAdmin && adminIds.length==1) {
+            errorDialog(context, "Error", "You cannot leave the team if "
+                "you are the only admin. You must promote someone else to admin "
+                "before leaving.");
+          } else {
+            await leaveTeam(token);
+            Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(builder: (context) =>
+                  TeamsList()),
+            );
+          }
+        },
+        color: Theme
+            .of(context)
+            .colorScheme
+            .secondary
+    );
+  }
+}
+
+class MemberListElement extends StatelessWidget {
+  final Member mem;
+  final bool isAdmin;
+  final List<String> adminIds;
+
+  const MemberListElement(this.mem, this.isAdmin, this.adminIds);
+
+  @override
+  Widget build(BuildContext context) {
+    String id = mem.id;
+    String emailStr = "(" + mem.email + ")";
+    String nameStr = mem.name;
+    bool isMemAdmin = adminIds.contains(id);
+
+    // Show promotion dialog
+    void promoteConfirm(String id) {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          String token = Provider.of<UserInfoModel>(context, listen: false).token;
+          return AlertDialog(
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+            title: Text("Confirmation", style: Theme.of(context).textTheme.headline1),
+            content: Text("Are you sure you want to promote this member to an admin? You will no longer be an admin.", style: Theme.of(context).textTheme.bodyText2),
+            actions: <Widget>[
+              TextButton(
+                child: Text(
+                  "Cancel",
+                  style: Theme.of(context).textTheme.headline4,
+                ),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+              TextButton(
+                child: Text(
+                  "OK",
+                  style: Theme.of(context).textTheme.headline4,
+                ),
+                onPressed: () {
+                  promoteToAdmin(id, token).then(
+                          (_) {
+                        Navigator.of(context).pop();
+                        Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();}
+                  );
+                },
+              ),
+            ],
+          );
+        },
+      );
+    }
+
+    return Container(
+        padding: const EdgeInsets.fromLTRB(0, 0, 0, 5),
+        child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    RichText(text: TextSpan(
+                        children: [
+                          TextSpan(text: nameStr + "  ", style: Theme
+                              .of(context)
+                              .textTheme
+                              .bodyText2),
+                          if (isMemAdmin)
+                            WidgetSpan(
+                                child: Icon(Icons.star,
+                                    size: 20,
+                                    color: Theme.of(context).colorScheme.tertiaryContainer)
+                            )
+                        ]
+                    )),
+                    Text(emailStr, style: Theme
+                        .of(context)
+                        .textTheme
+                        .bodyText2)
+                  ]
+              ),
+              if (isAdmin && !isMemAdmin)
+                SolidButton(
+                  text: "Promote",
+                  color: Theme.of(context).colorScheme.secondary,
+                  onPressed: () {
+                    promoteConfirm(id);
+                  },
+                )
+            ]
+        )
+    );
+  }
+}
+
+class TeamMembersList extends StatelessWidget {
+  final Team team;
+  final bool isAdmin;
+  final List<String> adminIds;
+
+  const TeamMembersList(this.team, this.isAdmin, this.adminIds);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text("Team Members", style: Theme
+              .of(context)
+              .textTheme
+              .headline4),
+          Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: team.members.map((mem) => MemberListElement(mem, isAdmin, adminIds)).toList()
+          )
+        ]
+    );
+  }
+}
+
+class TeamMail extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+        alignment: Alignment.centerRight,
+        child: IconButton(
+            icon: const Icon(Icons.email, size: 30.0),
+            color: Theme
+                .of(context)
+                .colorScheme
+                .tertiaryContainer,
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) =>
+                    ViewInvites()),
+              );
+            }
+        )
+    );
+  }
+}
+
+class TeamHeader extends StatelessWidget {
+  final bool isAdmin;
+
+  const TeamHeader(this.isAdmin);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+        height: 50,
+        child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text("TEAM", style: Theme
+                  .of(context)
+                  .textTheme
+                  .headline1),
+              isAdmin ? TeamMail() : Container()
+            ]
+        )
+    );
+  }
+}
+
+class TeamDesc extends StatelessWidget {
+  final Team team;
+
+  const TeamDesc(this.team);
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -132,222 +311,140 @@ class _ViewTeamState extends State<ViewTeam> {
         ]
     );
   }
+}
 
-  Widget _buildMember(Member mem) {
-    String id = mem.id;
-    String emailStr = "(" + mem.email + ")";
-    String nameStr = mem.name;
-    bool isMemAdmin = adminIds.contains(id);
-    return Container(
-        padding: const EdgeInsets.fromLTRB(0, 0, 0, 5),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  RichText(text: TextSpan(
-                      children: [
-                        TextSpan(text: nameStr + "  ", style: Theme
-                            .of(context)
-                            .textTheme
-                            .bodyText2),
-                        if (isMemAdmin)
-                          WidgetSpan(
-                              child: Icon(Icons.star,
-                                  size: 20,
-                                  color: Theme.of(context).colorScheme.tertiaryContainer)
-                          )
-                      ]
-                  )),
-                  Text(emailStr, style: Theme
-                      .of(context)
-                      .textTheme
-                      .bodyText2)
-                ]
-            ),
-            if (isAdmin && !isMemAdmin)
-            SolidButton(
-              text: "Promote",
-              color: Theme.of(context).colorScheme.secondary,
-              onPressed: () {
-                promoteConfirm(id);
-              },
-            )
-          ]
-        )
-    );
-  }
-
-  void promoteConfirm(String id) {
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        // return object of type Dialog
-        return AlertDialog(
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-          title: Text("Confirmation", style: Theme.of(context).textTheme.headline1),
-          content: Text("Are you sure you want to promote this member to an admin? You will no longer be an admin.", style: Theme.of(context).textTheme.bodyText2),
-          actions: <Widget>[
-            // usually buttons at the bottom of the dialog
-            TextButton(
-              child: Text(
-                "Cancel",
-                style: Theme.of(context).textTheme.headline4,
-              ),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            TextButton(
-              child: Text(
-                "OK",
-                style: Theme.of(context).textTheme.headline4,
-              ),
-              onPressed: () {
-                promoteToAdmin(id, token).then(
-                    (_) {
-                      Navigator.of(context).pop();
-                      Provider.of<UserInfoModel>(context).fetchUserInfo();}
-                );
-              },
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  Widget _inviteMessage() {
-    TextEditingController inviteController = TextEditingController();
-    String emailInvite;
-
-    return AlertDialog(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: Text('Send Invite', style: Theme.of(context).textTheme.headline1),
-        content: TextFormField(
-          decoration: const InputDecoration(labelText: "email"),
-          style: const TextStyle(color: Colors.black),
-          controller: inviteController,
-          validator: (String value) {
-            if (value.isEmpty) {
-              return 'An email is required';
-            }
-            return null;
-          },
-          onChanged: (String value) {
-            emailInvite = value;
-          },
-        ),
-      actions: [
-        TextButton(
-          child: Text(
-            "Cancel",
-            style: Theme.of(context
-            ).textTheme.headline4,
-          ),
-          onPressed: () async {
-            Navigator.of(context).pop();
-          },
-        ),
-        TextButton(
-          child: Text(
-            "Send",
-            style: Theme.of(context
-            ).textTheme.headline4,
-          ),
-          onPressed: () async {
-            await requestTeamMember(emailInvite, token);
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget _inviteMembersBtn() {
-    if (team.members.length < 4 && isAdmin && isMember) {
-      return SolidButton(
-          text: "INVITE NEW MEMBER",
-          onPressed: () {
-            showDialog(
-                context: context,
-                builder: (_) => _inviteMessage()
-            );
-          },
-          color: Theme
-              .of(context)
-              .colorScheme
-              .primary);
-    } else {
-      return Container();
-    }
-  }
-
-  Widget _buildTeamMembers() {
-
-    return Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text("Team Members", style: Theme
-              .of(context)
-              .textTheme
-              .headline4),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-              children: team.members.map((e) => _buildMember(e)).toList()
-          )
-        ]
-    );
-  }
-
-
-  Widget _leaveJoinTeamBtn() {
-    if (!isMember) return Container();
-    String buttonText = "Leave Team";
+class EditTeamButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
     return SolidButton(
-        text: buttonText,
+        text: "EDIT TEAM NAME AND INFO",
         onPressed: () {
-          if (isAdmin && adminIds.length==1) {
-            errorDialog(context, "Error", "You cannot leave the team if "
-                "you are the only admin. You must promote someone else to admin "
-                "before leaving.");
-          } else {
-            leaveTeam(token);
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) =>
-                  TeamsList()),
-            );
-          }
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) =>
+                CreateTeam()),
+          );
         },
         color: Theme
             .of(context)
             .colorScheme
-            .secondary);
+            .primary);
   }
+}
 
+class OwnTeamView extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    Team team = Provider.of<UserInfoModel>(context).team;
+    String id = Provider.of<UserInfoModel>(context).id;
+    Status status = Provider.of<UserInfoModel>(context).userInfoStatus;
+    List<String> adminIds = team.admins.map((mem) => mem.id).toList();
+    bool isAdmin = adminIds.contains(id);
+
+    return status == Status.loaded ? Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TeamHeader(isAdmin),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+                padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
+                child: TeamDesc(team)
+            ),
+            isAdmin ? EditTeamButton() : Container(),
+            Container(
+                padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
+                child: TeamMembersList(team, isAdmin, adminIds)
+            ),
+            if (isAdmin && team.members.length < 4) InviteMembersBtn(team),
+            const SizedBox(height: 10,),
+            LeaveJoinTeamBtn(team, isAdmin, adminIds)
+          ],
+        )
+      ],
+    ) : const Center(child: Padding(
+      child: CircularProgressIndicator(),
+      padding: EdgeInsets.symmetric(vertical: 50),
+    ));
+  }
+}
+
+class BrowseTeamView extends StatelessWidget {
+  final String teamId;
+  
+  const BrowseTeamView(this.teamId);
+  
+  @override
+  Widget build(BuildContext context) {
+    String token = Provider.of<UserInfoModel>(context, listen: false).token;
+    
+    return FutureBuilder(
+      future: getTeamInfo(teamId, token),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          Team team = snapshot.data;
+          String id = Provider.of<UserInfoModel>(context).id;
+          List<String> adminIds = team.admins.map((mem) => mem.id).toList();
+          bool isAdmin = adminIds.contains(id);
+          
+          return Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TeamHeader(isAdmin),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                      padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
+                      child: TeamDesc(team)
+                  ),
+                  Container(
+                      padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
+                      child: TeamMembersList(team, isAdmin, adminIds)
+                  ),
+                ],
+              )
+            ],
+          );
+        } else if (snapshot.hasError) {
+          return Center(
+            child: Padding(
+              child: Text("Could not load team data", style: Theme.of(context).textTheme.headline1,),
+              padding: const EdgeInsets.symmetric(vertical: 50),
+            ),
+          );
+        } else {
+          return const Center(child: Padding(
+            child: CircularProgressIndicator(),
+            padding: EdgeInsets.symmetric(vertical: 50),
+          ));
+        }
+      },
+    );
+  }
+}
+
+class ViewTeam extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mqData = MediaQuery.of(context);
     final screenHeight = mqData.size.height;
     final screenWidth = mqData.size.width;
 
-    hasTeam = Provider.of<UserInfoModel>(context).hasTeam;
-    team = Provider.of<UserInfoModel>(context).team;
-
-    String teamID = "";
+    String teamId = "";
     if (ModalRoute.of(context) != null) {
-      teamID = ModalRoute
+      teamId = ModalRoute
           .of(context)
           .settings
           .arguments as String;
     }
-    var _data = _getData(teamID, context);
 
     return DefaultPage(
-      backflag: teamID != "",
+      backflag: teamId != "",
       reverse: true,
       child:
           Container(
@@ -359,46 +456,7 @@ class _ViewTeamState extends State<ViewTeam> {
                   padding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
                   alignment: Alignment.topLeft,
                   child: SingleChildScrollView(
-                      child: FutureBuilder(
-                        future: _data,
-                        builder: (context, snapshot) {
-                          if (snapshot.connectionState == ConnectionState.done) {
-                            return Column(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  _buildTeamHeader(),
-                                  if (team != null)
-                                    Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Container(
-                                            padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
-                                            child: _buildTeamDesc()
-                                        ),
-                                        _buildEditTeam(),
-                                        Container(
-                                            padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
-                                            child: _buildTeamMembers()
-                                        ),
-                                        _inviteMembersBtn(),
-                                        const SizedBox(height: 10),
-                                        _leaveJoinTeamBtn()
-                                      ],
-                                    )
-                                  else
-                                    Center(child: CircularProgressIndicator(
-                                        color: Theme.of(context).colorScheme.onSurface))
-                                ]
-                            );
-                          } else {
-                            return const Center(child: Padding(
-                                child: CircularProgressIndicator(),
-                              padding: EdgeInsets.symmetric(vertical: 50),
-                            ));
-                          }
-                        },
-                      )
+                      child: teamId == "" ? OwnTeamView() : BrowseTeamView(teamId)
                   )
               )
           )

--- a/lib/providers/check_in_items_provider.dart
+++ b/lib/providers/check_in_items_provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -17,12 +17,14 @@ class UserInfoModel with ChangeNotifier {
   String _token = "";
   String _uid = "";
 
-  Profile userProfile = null;
-  Team team = null;
+  Profile userProfile;
+  Team team;
   bool hasTeam = false;
   bool isAdmin = false;
 
   Status get userInfoStatus => _status;
+  String get id => _uid;
+  String get token => _token;
 
   void handleException(e) {
     _status = Status.error;
@@ -51,13 +53,13 @@ class UserInfoModel with ChangeNotifier {
   }
 
   void reset() {
-    Status _status = Status.notLoaded;
-    String _token = "";
-    String _uid = "";
+    _status = Status.notLoaded;
+    _token = "";
+    _uid = "";
 
-    Profile userProfile = null;
-    Team team = null;
-    bool hasTeam = false;
-    bool isAdmin = false;
+    userProfile = null;
+    team = null;
+    hasTeam = false;
+    isAdmin = false;
   }
 }

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:thdapp/api.dart';
+import 'package:thdapp/models/profile.dart';
+import 'package:thdapp/models/team.dart';
+import 'package:thdapp/pages/team_api.dart';
+
+enum Status {
+  notLoaded,
+  fetching,
+  loaded,
+  error
+}
+
+class UserInfoModel with ChangeNotifier {
+  Status _status = Status.notLoaded;
+  String _token = "";
+  String _uid = "";
+
+  Profile userProfile = null;
+  Team team = null;
+  bool hasTeam = false;
+  bool isAdmin = false;
+
+  Status get userInfoStatus => _status;
+
+  void handleException(e) {
+    _status = Status.error;
+    notifyListeners();
+  }
+
+  Future<void> fetchUserInfo() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+    _token = prefs.getString("token");
+    _uid = prefs.getString("id");
+    isAdmin = prefs.getBool("admin");
+    if (_status == Status.notLoaded) {
+      _status = Status.fetching;
+    }
+
+    try {
+      userProfile = await getProfile(_uid, _token);
+      team = await getUserTeam(_token);
+      hasTeam = team != null;
+      _status = Status.loaded;
+      notifyListeners();
+    } on Exception catch(e) {
+      handleException(e);
+    }
+  }
+
+  void reset() {
+    Status _status = Status.notLoaded;
+    String _token = "";
+    String _uid = "";
+
+    Profile userProfile = null;
+    Team team = null;
+    bool hasTeam = false;
+    bool isAdmin = false;
+  }
+}


### PR DESCRIPTION
### Changes

#### Team state refactors
- Added a UserInfoProvider which stores global state on the user Profile, Team and api access token
- Refactored CreateTeam, SeeInvites and ViewTeam pages to use the UserInfoProvider state instead of making API calls each time
- Those pages now automatically update based on changes to the UserInfoProvider state without having to push a new page to display the updated information
- Replaced functional widgets with classes for SeeInvites and ViewTeam pages

#### SeeInvites page
- Added pull down to refresh list of invites

#### MenuOverlay
- Updated navigation such that there is only at most one page above the Home page at any time rather than stacking each new page on top of all previous pages
- "Team" button now correctly navigates to ViewTeam or TeamsList (no longer needs double segue, solves #58)
- Minor fix to theming (yellow text underlines are now gone)

#### CreateTeam
- Removed "INVITE NEW MEMBER" button (functionality duplicated in ViewTeam screen)

#### TeamsList page
- Updated "Pending response" text color