### PR TITLE
Fix the contrast of buttons on the login screens

### DIFF
--- a/lib/pages/forgot.dart
+++ b/lib/pages/forgot.dart
@@ -114,7 +114,7 @@ class _ForgotState extends State<Forgot>{
                           Text("Already have an account?",
                               style: TextStyle(
                                 fontSize: 14,
-                                color: Theme.of(context).colorScheme.primary
+                                color: Theme.of(context).colorScheme.onPrimary
                               )
                           ),
                           TextButton(
@@ -128,7 +128,7 @@ class _ForgotState extends State<Forgot>{
                               child: Text("Try Logging In",
                                   style: TextStyle(
                                     fontSize: 14,
-                                    color: Theme.of(context).colorScheme.secondary
+                                    color: Theme.of(context).colorScheme.tertiary
                                   )
                               )
                           ),

--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -173,7 +173,7 @@ class _LoginState extends State<Login> {
                           child: Text("Forgot Password",
                               style: TextStyle(
                                   color:
-                                      Theme.of(context).colorScheme.primary))),
+                                      Theme.of(context).colorScheme.tertiary))),
                     ]))));
   }
 }


### PR DESCRIPTION
# Description

This PR changes the colors of the tertiary buttons on the login screens to improve contrast.

<img width="565" alt="Screenshot 2023-01-21 at 15 15 09" src="https://user-images.githubusercontent.com/7029582/213885552-255790f4-38cd-495c-b8e0-b75a43780118.png">
<img width="565" alt="Screenshot 2023-01-21 at 15 14 57" src="https://user-images.githubusercontent.com/7029582/213885554-86f01a68-6848-4a18-be2e-11e4297f77d4.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually on the iOS 16.2 simulator

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
