### PR TITLE
Profile image: cropping and deleting

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -689,4 +689,21 @@ Future<bool> uploadProfilePic(io.File profilePicFile, String token) async {
   }
 }
 
+Future<bool> deleteProfilePic(String token) async {
+  String url = baseUrl + "user/profile-picture";
+  final http.Response response = await http.delete(
+    Uri.parse(url),
+    headers: <String, String>{
+      'Content-Type': 'application/json',
+      "x-access-token": token
+    },
+  );
+  if (response.statusCode == 200) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
 

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 // getting to the gallery
 import 'package:image_picker/image_picker.dart';
+import 'package:image_cropper/image_cropper.dart';
 
 class ProfilePage extends StatefulWidget {
   final Map bookmarks;
@@ -170,8 +171,28 @@ class _ProfilePageState extends State<ProfilePage> {
                     crossAxisAlignment: CrossAxisAlignment.center,
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
+                      ButtonBar(alignment: MainAxisAlignment.center, children: [
+                        SolidButton(
+                            text: "Delete Uploaded Picture",
+                            onPressed: () async {
+                              if (Image.network(userData.profilePicture) != null) {
+                                OverlayEntry loading = loadingOverlay(context);
+                                Overlay.of(context).insert(loading);
+                                bool didUpload = await deleteProfilePic(token);
+                                if (!didUpload) {
+                                  errorDialog(context, "Error",
+                                      "An error occurred. Please try again.");
+                                }
+                                else {
+                                  loading.remove();
+                                }
+                              }
+                            }
+                        )
+                      ]),
                       AspectRatio(aspectRatio: 1.0 / 1.0,
-                          child: profilePicFile != null ? Image.file(profilePicFile) : Image.network(userData.profilePicture, errorBuilder:(BuildContext context, Object exception, StackTrace stackTrace) {return Image.asset('lib/logos/defaultpfp.PNG');},)),
+                          child: profilePicFile != null ? Image.file(profilePicFile) : Container(color: Colors.black, child: Center(child:Text("No picture chosen", style: const TextStyle(color: Colors.white))))
+                      ),
                       ButtonBar(alignment: MainAxisAlignment.center,
                           children: [SolidButton(
                             text: "Gallery",
@@ -184,9 +205,16 @@ class _ProfilePageState extends State<ProfilePage> {
                               onPressed: () {
                               _getImage(ImageSource.camera, setState);
                               }
-                            )
+                            ),
+                            SolidButton(
+                              text: "Crop",
+                              onPressed: () {
+                                _cropPicture(setState);
+                              }
+                            ),
                           ]
                       ),
+
                     ],
                   ),
                 ),
@@ -226,7 +254,23 @@ class _ProfilePageState extends State<ProfilePage> {
     ).then((value) => getData());
   }
 
- _getImage(ImageSource source, setState) async {
+ _cropPicture(setState) async {
+    if (profilePicFile != null) {
+      profilePicFile = await ImageCropper().cropImage(
+      sourcePath: profilePicFile != null ? profilePicFile.path: Uri.parse(userData.profilePicture).path,
+      aspectRatioPresets: [
+      CropAspectRatioPreset.square,
+      ],);
+      setState((){
+      });
+    }
+    else {
+      errorDialog(context, "Error", 'No file uploaded from phone');
+    }
+ }
+
+
+  _getImage(ImageSource source, setState) async {
     profilePicFile = await ImagePicker.pickImage(source: source);
     setState((){
     });
@@ -320,20 +364,23 @@ class _ProfilePageState extends State<ProfilePage> {
                                   padding: const EdgeInsets.fromLTRB(
                                       0, 10, 0, 10),
                                   child: Row(
+                                    mainAxisSize: MainAxisSize.min,
                                     children: [
-                                      //make stack with this and add a gesture detector as a child
                                       GestureDetector(
                                           onTap: (){
                                             _editPicture();
                                           },
                                           child:
+                                          AspectRatio(aspectRatio: 1/1, child:
                                           ClipRRect(
                                             borderRadius: BorderRadius
                                                 .circular(10),
                                               child:
-                                                  AspectRatio(aspectRatio:1/1, child:
-                                                  Image.network(userData.profilePicture, fit: BoxFit.cover, errorBuilder:(BuildContext context, Object exception, StackTrace stackTrace) {return Image.asset('lib/logos/defaultpfp.PNG');}))),
-                                      ),
+                                                Container(color: Colors.black, child: Center(child: userData.profilePicture != null ?
+                                                  Image.network(userData.profilePicture, fit: BoxFit.cover, errorBuilder:(BuildContext context, Object exception, StackTrace stackTrace) {return Image.asset('lib/logos/defaultpfp.PNG');}): Image.asset('lib/logos/defaultpfp.PNG')),
+                                          )
+                                          ),
+                                      )),
                                       const SizedBox(width: 25),
                                       Expanded(
                                           child: Column(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,6 +92,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -276,6 +283,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.5"
   pedantic:
     dependency: transitive
     description:
@@ -297,6 +325,10 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  name: plugin_platform_interface
+    url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   platform_detect:
     dependency: transitive
     description:
@@ -353,6 +385,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.7+3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+4"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+3"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -442,6 +488,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
   url_launcher_macos:
     dependency: transitive
     description:
@@ -449,6 +502,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1+9"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -484,6 +544,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.6.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   xml:
     dependency: transitive
     description:
@@ -492,5 +566,5 @@ packages:
     source: hosted
     version: "5.4.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,13 +92,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -180,6 +173,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  image_cropper:
+    dependency: "direct main"
+    description:
+      name: image_cropper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   image_picker:
     dependency: "direct main"
     description:
@@ -276,27 +276,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+2"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.5"
   pedantic:
     dependency: transitive
     description:
@@ -318,13 +297,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
-  plugin_platform_interface:
+  platform_detect:
     dependency: transitive
     description:
-      name: plugin_platform_interface
+      name: platform_detect
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.4.0"
   process:
     dependency: transitive
     description:
@@ -339,6 +318,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.0.5"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.4"
   qr:
     dependency: transitive
     description:
@@ -366,14 +352,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.12+4"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+4"
+    version: "0.5.7+3"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -395,13 +374,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2+7"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -469,14 +441,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.10"
-  url_launcher_linux:
-    dependency: transitive
-    description:
-      name: url_launcher_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+4"
+    version: "5.4.0"
   url_launcher_macos:
     dependency: transitive
     description:
@@ -490,21 +455,14 @@ packages:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.9"
+    version: "1.0.1"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5+3"
-  url_launcher_windows:
-    dependency: transitive
-    description:
-      name: url_launcher_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+3"
+    version: "0.1.3"
   vector_math:
     dependency: transitive
     description:
@@ -526,20 +484,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.6.1"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   xml:
     dependency: transitive
     description:
@@ -548,5 +492,5 @@ packages:
     source: hosted
     version: "5.4.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   flutter_svg: ^0.22.0
   decorated_icon: ^1.2.1
   image_picker:
+  image_cropper: ^1.5.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Allows for user to crop photos they want to upload as a profile picture (1:1 aspect ratio enforced) and clear their profile picture to be blank. It also has box for profile picture to be 1:1 aspect ratio. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Uploading picture and then cropping
- Deleting profile picture

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Python version:
- Desktop/Mobile:
- OS:
- Browser:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
