### PR TITLE
Leaving team as the only member left, team invites bug fixes

### DIFF
--- a/lib/components/loading/ListRefreshable.dart
+++ b/lib/components/loading/ListRefreshable.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ListRefreshable extends StatelessWidget {
+  Widget child;
+
+  ListRefreshable({this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        ListView(
+          shrinkWrap: true,
+          children: const [
+            SizedBox(width: 100, height: 500,)
+          ],
+        ),
+        child
+      ],
+    );
+  }
+}

--- a/lib/pages/see_invites.dart
+++ b/lib/pages/see_invites.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:thdapp/components/DefaultPage.dart';
 import 'package:thdapp/components/buttons/GradBox.dart';
 import 'package:thdapp/components/buttons/SolidButton.dart';
+import 'package:thdapp/components/loading/ListRefreshable.dart';
 import 'package:thdapp/providers/user_info_provider.dart';
 import 'team_api.dart';
 import '/models/team.dart';
@@ -94,19 +95,26 @@ class RequestCard extends StatelessWidget {
                 Text(inviteInfo, style: Theme.of(context).textTheme.bodyText2),
                 const SizedBox(height: 8),
                 canAccept ? AcceptButtonRow(acceptOnPressed: () async {
-                  await acceptRequest(token, requestID);
-                  removeRequest(request);
+                  bool success = await acceptRequest(token, requestID);
+                  if (!success) {
+                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                      content: Text("Error accepting invite. "
+                          "Please request for the invite to be resent."),
+                    ));
+                    removeRequest(request);
+                  }
                   await Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();
                   if (requestType == 'INVITE') {
                     Navigator.pushAndRemoveUntil(
                         context,
                         MaterialPageRoute(
-                            builder: (context) => ViewTeam(),
+                            builder: (ctx) => ViewTeam(),
                             settings: const RouteSettings(
                               arguments: "",
                             )
                         ), (route) => route.isFirst);
                   }
+                  removeRequest(request);
                 }, declineOnPressed: () async {
                   await declineRequest(token, requestID);
                   removeRequest(request);
@@ -199,9 +207,9 @@ class _ViewInvitesState extends State<ViewInvites> {
                               ),
                             )
                           else if (fetchStatus == Status.loaded && requestsList.isEmpty)
-                            Text("No invites", style: Theme.of(context).textTheme.bodyText2,)
+                            ListRefreshable(child: Text("No invites", style: Theme.of(context).textTheme.bodyText2,))
                           else if (fetchStatus == Status.error)
-                              Text("Error loading invites", style: Theme.of(context).textTheme.bodyText2,)
+                            ListRefreshable(child: Text("Error loading invites", style: Theme.of(context).textTheme.bodyText2,))
                           else
                             const Center(child: CircularProgressIndicator())
                         ]

--- a/lib/pages/team_api.dart
+++ b/lib/pages/team_api.dart
@@ -89,14 +89,15 @@ Future<List<dynamic>> getTeamMail(String token) async {
   return null;
 }
 
-Future<void> acceptRequest(String token, String requestID) async {
+Future<bool> acceptRequest(String token, String requestID) async {
   String url =
       baseUrl + "requests/accept/" + requestID;
   Map<String, String> headers = {
     "Content-type": "application/json",
     "x-access-token": token
   };
-  await http.post(url, headers: headers);
+  http.Response response = await http.post(url, headers: headers);
+  return response.statusCode == 200;
 }
 
 Future<void> cancelRequest(String token, String requestID) async {
@@ -116,7 +117,10 @@ Future<void> declineRequest(String token, String requestID) async {
     "Content-type": "application/json",
     "x-access-token": token
   };
-  await http.post(url, headers: headers);
+  print(url);
+  print(headers.toString());
+  http.Response response = await http.post(url, headers: headers);
+  print(response.body);
 }
 
 Future<List<dynamic>> getUserMail(String token) async {
@@ -143,7 +147,7 @@ Future<void> inviteTeamMember(String userEmail, String token) async {
   await http.post(url, headers: headers, body: body);
 }
 
-Future<void> leaveTeam(String token) async {
+Future<bool> leaveTeam(String token) async {
   const url = baseUrl + "team/leave";
   Map<String, String> headers = {
     "Content-type": "application/json",
@@ -151,9 +155,7 @@ Future<void> leaveTeam(String token) async {
   };
   var body = json.encode({});
   final response = await http.post(url, headers: headers, body: body);
-  if (response.statusCode == 200) {
-    return;
-  }
+  return response.statusCode == 200;
 }
 
 Future<bool> requestTeam(String teamID, String token) async {

--- a/lib/pages/teams_list.dart
+++ b/lib/pages/teams_list.dart
@@ -5,6 +5,7 @@ import 'package:thdapp/components/DefaultPage.dart';
 import 'package:thdapp/components/ErrorDialog.dart';
 import 'package:thdapp/components/buttons/GradBox.dart';
 import 'package:thdapp/components/buttons/SolidButton.dart';
+import 'package:thdapp/components/loading/ListRefreshable.dart';
 import '../components/loading/LoadingOverlay.dart';
 import '../providers/user_info_provider.dart';
 import 'create_team.dart';
@@ -239,13 +240,13 @@ class _TeamsListState extends State<TeamsList> {
                             height: 20
                         ),
                         if (fetchStatus == Status.error)
-                          const Center(
-                            child: Text("Error loading teams")
-                          )
+                          ListRefreshable(child: const Center(
+                              child: Text("Error loading teams")
+                          ),)
                         else if (fetchStatus == Status.loaded && teams.isEmpty)
-                          const Center(
-                            child: Text("No teams available")
-                          )
+                          ListRefreshable(child: const Center(
+                              child: Text("No teams available")
+                            ))
                         else if (fetchStatus == Status.loaded)
                           Expanded(
                             child: ListView.builder(

--- a/lib/pages/teams_list.dart
+++ b/lib/pages/teams_list.dart
@@ -164,7 +164,7 @@ class _TeamsListState extends State<TeamsList> {
     teams = teams.where((e) => e.visible).toList();
     teams.sort((a, b) => a.name.compareTo(b.name));
     List requestsList = await getUserMail(token);
-    requestedTeams = requestsList.map((e) => e['team']['_id'].toString()).toSet();
+    requestedTeams = requestsList?.map((e) => e['team']['_id'].toString())?.toSet() ?? {};
     fetchStatus = Status.loaded;
     setState(() {});
 


### PR DESCRIPTION
- Warning dialogs for leaving the team
- Can now leave team if user is either not the admin or is the last person on the team, closes #86
- Error snackbars for invites and leaving the team
- Fixed bugs where accepting or declining an invite wouldn't load the correct page, closes #83
- Fixed bug where pull down to refresh wasn't working on Text widgets (e.g. text that appears when teams list is empty) within RefreshIndicators with new ListRefreshable widget