### PR TITLE
Fix Android autofill

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,11 +40,7 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
         <meta-data android:name="asset_statements" android:resource="@string/asset_statements" />
-        <string name="asset_statements" translatable="false">
-            [{
-            \"include\": \"https://tartanhacks.com/.well-known/assetlinks.json\"
-            }]
-        </string>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,13 @@
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+
+        <meta-data android:name="asset_statements" android:resource="@string/asset_statements" />
+        <string name="asset_statements" translatable="false">
+            [{
+            \"include\": \"https://tartanhacks.com/.well-known/assetlinks.json\"
+            }]
+        </string>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="asset_statements" translatable="false">
+    [{
+    \"include\": \"https://tartanhacks.com/.well-known/assetlinks.json\"
+    }]
+    </string>
+</resources>


### PR DESCRIPTION
# Description

Adds tartanhacks.com site association for Android password autofill.

Closes #7 

Couldn't be tested because apps need "to be released in the public channel for associations to be picked up" [(see here)](https://developers.google.com/identity/smartlock-passwords/android/associate-apps-and-sites)