### PR TITLE
Fix Discord launcher with AndroidManifest.xml queries

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,14 @@
         </intent>
     </queries>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name="${applicationName}"
         android:label="TartanHacks Dashboard"


### PR DESCRIPTION
# Description

Fix Discord failed to launch due to missing permissions to access packages. This was fixed by adding queries to the AndroidManifest.xml.