### PR TITLE
Teams Page Fixes

### DIFF
--- a/lib/pages/see_invites.dart
+++ b/lib/pages/see_invites.dart
@@ -150,15 +150,27 @@ class _ViewInvitesState extends State<ViewInvites> {
   Future<void> fetchData() async {
     String token = Provider.of<UserInfoModel>(context, listen: false).token;
     bool hasTeam = Provider.of<UserInfoModel>(context, listen: false).hasTeam;
-    List<dynamic> fetchedList;
+    List<dynamic>? fetchedList;
     if (hasTeam) {
       fetchedList = await getTeamMail(token);
     } else {
-      fetchedList = await getUserMail(token);
+      try {
+        fetchedList = await getUserMail(token);
+      } on String catch (e) {
+        if (e.toString().contains("You're already in a team!")) {
+          await Provider.of<UserInfoModel>(context, listen: false)
+              .fetchUserInfo();
+          Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (context) => ViewTeam()),
+              (route) => route.isFirst);
+        }
+      }
+
     }
     setState(() {
       fetchStatus = fetchedList == null ? Status.error : Status.loaded;
-      requestsList = fetchedList;
+      requestsList = fetchedList ?? [];
     });
   }
 

--- a/lib/pages/team_api.dart
+++ b/lib/pages/team_api.dart
@@ -103,7 +103,7 @@ Future<void> cancelRequest(String token, String requestID) async {
 
 Future<void> declineRequest(String token, String requestID) async {
   String url =
-      "${baseUrl}requests/cancel/$requestID";
+      "${baseUrl}requests/decline/$requestID";
   Map<String, String> headers = {
     "Content-type": "application/json",
     "x-access-token": token
@@ -125,7 +125,7 @@ Future<List<dynamic>> getUserMail(String token) async {
     var data = json.decode(response.body);
     return data;
   }
-  throw Error();
+  throw response.body;
 }
 
 Future<void> inviteTeamMember(String userEmail, String token) async {

--- a/lib/pages/teams_list.dart
+++ b/lib/pages/teams_list.dart
@@ -165,11 +165,6 @@ class _TeamsListState extends State<TeamsList> {
     teams = await getTeams(token);
     teams = teams.where((e) => e.visible).toList();
     teams.sort((a, b) => a.name.compareTo(b.name));
-    List requestsList = await getUserMail(token);
-    requestedTeams =
-        requestsList.map((e) => e['team']['_id'].toString()).toSet() ?? {};
-    fetchStatus = Status.loaded;
-    setState(() {});
 
     // Reload user's team and redirect to ViewTeam page if user has a team
     await Provider.of<UserInfoModel>(context, listen: false).fetchUserInfo();
@@ -180,7 +175,14 @@ class _TeamsListState extends State<TeamsList> {
           MaterialPageRoute(
               builder: (context) => ViewTeam(),
               settings: const RouteSettings(arguments: "")));
+      return;
     }
+
+    List requestsList = await getUserMail(token);
+    requestedTeams =
+        requestsList.map((e) => e['team']['_id'].toString()).toSet() ?? {};
+    fetchStatus = Status.loaded;
+    setState(() {});
   }
 
   @override
@@ -195,7 +197,7 @@ class _TeamsListState extends State<TeamsList> {
             alignment: Alignment.center,
             padding: const EdgeInsets.fromLTRB(0, 5, 0, 0),
             child: RefreshIndicator(
-              onRefresh: () {
+              onRefresh: () async {
                 searchController.clear();
                 return fetchData();
               },

--- a/lib/pages/view_team.dart
+++ b/lib/pages/view_team.dart
@@ -144,10 +144,10 @@ class LeaveJoinTeamBtn extends StatelessWidget {
               ));
               return;
             }
-            await Provider.of<UserInfoModel>(context, listen: false)
-                .fetchUserInfo();
-            Navigator.pushReplacement(
-                context, MaterialPageRoute(builder: (context) => TeamsList()));
+            Navigator.pushAndRemoveUntil(
+                context, MaterialPageRoute(builder: (context) => TeamsList()),
+                (route) => route.isFirst
+            );
           });
         },
         color: Theme.of(context).colorScheme.tertiaryContainer);
@@ -171,43 +171,51 @@ class MemberListElement extends StatelessWidget {
     return Container(
         padding: const EdgeInsets.fromLTRB(0, 0, 0, 5),
         child:
-            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-          Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                RichText(
-                    text: TextSpan(children: [
-                  TextSpan(
-                      text: "$nameStr  ",
-                      style: Theme.of(context).textTheme.bodyMedium),
-                  if (isMemAdmin)
-                    WidgetSpan(
-                        child: Icon(Icons.star,
-                            size: 20,
-                            color: Theme.of(context)
-                                .colorScheme
-                                .tertiaryContainer))
-                ])),
-                Text(emailStr, style: Theme.of(context).textTheme.bodyMedium)
-              ]),
+            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+          Expanded(
+            child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  RichText(
+                    overflow: TextOverflow.ellipsis,
+                      text: TextSpan(children: [
+                    TextSpan(
+                        text: nameStr,
+                        style: Theme.of(context).textTheme.bodyMedium),
+                    if (isMemAdmin)
+                      WidgetSpan(
+                          child: Icon(Icons.star,
+                              size: 20,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .tertiaryContainer))
+                  ])),
+                  Text(emailStr, style: Theme.of(context).textTheme.bodyMedium, overflow: TextOverflow.ellipsis,)
+                ]),
+          ),
           if (isAdmin && !isMemAdmin)
-            SolidButton(
-              text: "Promote",
-              color: Theme.of(context).colorScheme.secondary,
-              onPressed: () {
-                showConfirmDialog(context,
-                    "Are you sure you want to promote this member to an admin? You will no longer be an admin.",
-                    () {
-                  String token =
-                      Provider.of<UserInfoModel>(context, listen: false).token;
-                  promoteToAdmin(id, token).then((_) {
-                    Navigator.of(context).pop();
-                    Provider.of<UserInfoModel>(context, listen: false)
-                        .fetchUserInfo();
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
+              child: SolidButton(
+                text: "Promote",
+                color: Theme.of(context).colorScheme.secondary,
+                onPressed: () {
+                  showConfirmDialog(context,
+                      "Are you sure you want to promote this member to an admin? You will no longer be an admin.",
+                      () {
+                    String token =
+                        Provider.of<UserInfoModel>(context, listen: false).token;
+                    promoteToAdmin(id, token).then((_) {
+                      Navigator.of(context).pop();
+                      Provider.of<UserInfoModel>(context, listen: false)
+                          .fetchUserInfo();
+                    });
                   });
-                });
-              },
+                },
+              ),
             )
         ]));
   }
@@ -415,7 +423,7 @@ class ViewTeam extends StatelessWidget {
 
     String teamId = "";
     if (ModalRoute.of(context) != null) {
-      teamId = ModalRoute.of(context)?.settings.arguments as String;
+      teamId = ModalRoute.of(context)?.settings.arguments as String? ?? "";
     }
 
     return DefaultPage(
@@ -430,8 +438,13 @@ class ViewTeam extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
                 alignment: Alignment.topLeft,
                 child: SingleChildScrollView(
-                    child: teamId == ""
-                        ? OwnTeamView()
-                        : BrowseTeamView(teamId)))));
+                    child: () {
+                      if (teamId == "") {
+                        return OwnTeamView();
+                      } else {
+                        return BrowseTeamView(teamId);
+                      }
+                    }()
+                       ))));
   }
 }


### PR DESCRIPTION
- Updated endpoint of the team invite `declineRequest` api call to the correct url
- Added text overflow ellipses for the `OwnTeamView` page so that long usernames and emails do not push other UI elements (i.e. admin promotion button) off screen
- Pulling to refresh from the `ViewInvites` screen now automatically redirects to the `OwnTeamView` page if the user has just been accepted into a team 
- Changed some routing logic to avoid casting null values to non-nullable types